### PR TITLE
Fixed matching for fsw_project_path

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -286,7 +286,7 @@ retrieve_remote_requirements() {
 
     # Extract the repo owner and name from the remote URL
     local github_baseurl="github.com"
-    local fsw_project_path=$(git remote get-url origin | sed -nE "s/^.*${github_baseurl}[:/](.*)(\.git)?$/\1/p")
+    local fsw_project_path=$(git remote get-url origin | sed -nE "s/^.*${github_baseurl}[:/]([^\.]*)(\.git)?$/\1/p")
 
     # Get the .gitmodules content - add -L flag to follow redirects
     local submodule_url="https://api.github.com/repos/${fsw_project_path}/contents/.gitmodules?ref=${fsw_repo_commit}"

--- a/run.sh
+++ b/run.sh
@@ -286,7 +286,7 @@ retrieve_remote_requirements() {
 
     # Extract the repo owner and name from the remote URL
     local github_baseurl="github.com"
-    local fsw_project_path=$(git remote get-url origin | sed -nE "s/.*${github_baseurl}[:/](.*)(\.git)?$/\1/p")
+    local fsw_project_path=$(git remote get-url origin | sed -nE "s/^.*${github_baseurl}[:/](.*)(\.git)?$/\1/p")
 
     # Get the .gitmodules content - add -L flag to follow redirects
     local submodule_url="https://api.github.com/repos/${fsw_project_path}/contents/.gitmodules?ref=${fsw_repo_commit}"

--- a/run.sh
+++ b/run.sh
@@ -286,7 +286,7 @@ retrieve_remote_requirements() {
 
     # Extract the repo owner and name from the remote URL
     local github_baseurl="github.com"
-    local fsw_project_path=$(git remote get-url origin | sed -nE "s/.*(${github_baseurl})[:/](.*)\.git/\2/p")
+    local fsw_project_path=$(git remote get-url origin | sed -nE "s/.*${github_baseurl}[:/](.*)(\.git)?$/\1/p")
 
     # Get the .gitmodules content - add -L flag to follow redirects
     local submodule_url="https://api.github.com/repos/${fsw_project_path}/contents/.gitmodules?ref=${fsw_repo_commit}"


### PR DESCRIPTION
Before this patch, if the project was cloned without the `.git` suffix in the origin URL, the sed pattern matching would break in the `run.sh`, preventing its usage. This simple PR fixes that.